### PR TITLE
Add LISTAGG aggregate function

### DIFF
--- a/test/01_functions.sql
+++ b/test/01_functions.sql
@@ -1,0 +1,10 @@
+-- Postgres STRING_AGG
+-- See https://www.postgresql.org/docs/9.5/functions-aggregate.html
+SELECT STRING_AGG(x,'|') FROM (VALUES('a'),('b'),('c')) t(x); -- 'a|b|c'
+
+-- Note: Redshift LISTAGG requires a table field
+-- See https://docs.aws.amazon.com/redshift/latest/dg/r_LISTAGG.html
+SELECT LISTAGG_SFUNC((ARRAY['a','b'], ''), 'c', ','); -- ({a,b,c}, ',') (a LISTAGG_TYPE)
+SELECT LISTAGG_FINAL((ARRAY['a','b','c'], ','), NULL, NULL); -- 'a,b,c'
+SELECT LISTAGG(x, '$') FROM (VALUES('a'),('b'),('c')) t(x); -- 'a$b$c'
+


### PR DESCRIPTION
An attempt to port [LISTAGG](https://docs.aws.amazon.com/redshift/latest/dg/r_LISTAGG.html) to postgres.

This was not as straightforward due to the fact that `finalfunc` only takes a single parameter. 